### PR TITLE
Update aider-issue-to-pr.yml

### DIFF
--- a/.github/workflows/aider-issue-to-pr.yml
+++ b/.github/workflows/aider-issue-to-pr.yml
@@ -212,7 +212,7 @@ jobs:
 
             console.log(`Created PR #${newPR.data.number}: ${newPR.data.html_url}`);
       - name: Upload aider chat history
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: aider-chat-output
           path: ".aider.chat.history.md"


### PR DESCRIPTION
With the current code I was getting:
```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

When running the workflow. This updates `actions/upload-artifact` to `v3`.